### PR TITLE
Allows bottle-memcache to set the timeout value in python-memcached.

### DIFF
--- a/bottle_memcache.py
+++ b/bottle_memcache.py
@@ -13,11 +13,13 @@ class MemcachePlugin(object):
     name = 'memcache'
 
     def __init__(self, servers=['localhost:11211', ], keyword='mc',
-        server_max_value_length=memcache.SERVER_MAX_VALUE_LENGTH):
+                 server_max_value_length=memcache.SERVER_MAX_VALUE_LENGTH,
+                 socket_timeout=memcache._SOCKET_TIMEOUT):
 
         self.servers = servers
         self.keyword = keyword
         self.server_max_value_length = server_max_value_length
+        self.socket_timeout = socket_timeout
 
     def setup(self, app):
         for other in app.plugins:
@@ -31,16 +33,22 @@ class MemcachePlugin(object):
         conf = context['config'].get('memcache') or {}
         self.servers = conf.get('servers', self.servers)
         self.keyword = conf.get('keyword', self.keyword)
-        self.server_max_value_length = conf.get('server_max_value_length',
-            self.server_max_value_length)
+        self.server_max_value_length = conf.get(
+            'server_max_value_length', self.server_max_value_length
+        )
+        self.socket_timeout = conf.get('socket_timeout', self.socket_timeout)
 
         args = inspect.getargspec(context['callback'])[0]
         if self.keyword not in args:
             return callback
 
         def wrapper(*args, **kwargs):
-            mc = memcache.Client(servers=self.servers,
-                server_max_value_length=self.server_max_value_length, debug=0)
+            mc = memcache.Client(
+                servers=self.servers,
+                server_max_value_length=self.server_max_value_length,
+                socket_timeout=self.socket_timeout,
+                debug=0
+            )
             kwargs[self.keyword] = mc
             rv = callback(*args, **kwargs)
             return rv


### PR DESCRIPTION
The default value for socket timeout is too large (3 seconds). This patch allows bottle-memcache to set the value in python-memcached.
